### PR TITLE
feat : card에 마우스오버 시 설명 부분 추가 rev.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,3 +435,27 @@ lecture파일에 합쳐서 작업했습니다.
 - [ ] 이용약관, 개인정보취급방침 페이지 생성
 
 </details>
+
+<details>
+<summary>2021.08.12(Tony)</summary>
+
+### 메인페이지 리스트에 로딩 스피너 추가
+
+- 서버사이드 렌더링이기 때문에 필요 없을 것 같기도 함
+- 재미로 추가 해봄
+
+### 메인페이지 강의 리스트
+
+- 마우스 호버 시 나오는 description 추가
+- [ ] 장바구니, 좋아요 등 아이콘에 설명 라벨 추가 해야 함
+- [ ] 카드 전체적으로 크기 키워야 함
+
+### 기타
+
+- 컴포넌트 파일명 첫글자 대문자로 변경(노아님 요청사항)
+
+### 참고문헌
+
+- [react onHover event handling](https://upmostly.com/tutorials/react-onhover-event-handling-with-examples)
+
+</details>

--- a/src/api/dummyData.ts
+++ b/src/api/dummyData.ts
@@ -77,7 +77,7 @@ export const generateDummyLectureList = (num: number): ILecture[] =>
       description: faker.lorem.sentences(),
       level: 'intermediate',
       hashTags: ['React', 'Front-end'],
-      categories: ['프레임워크 및 라이브러리, 웹 개발'],
+      categories: ['프레임워크 및 라이브러리', '웹 개발'],
     }));
 
 // {

--- a/src/api/dummyData.ts
+++ b/src/api/dummyData.ts
@@ -74,8 +74,10 @@ export const generateDummyLectureList = (num: number): ILecture[] =>
       isExclusive: true,
       onDiscount: Math.floor(Math.random() * 5) * 10,
       createdAt: new Date(faker.datatype.datetime()),
-      description: faker.lorem.paragraph(),
+      description: faker.lorem.sentences(),
       level: 'intermediate',
+      hashTags: ['React', 'Front-end'],
+      categories: ['프레임워크 및 라이브러리, 웹 개발'],
     }));
 
 // {

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,5 +1,5 @@
-import Footer from './footer';
-import Header from './header';
+import Footer from './Footer';
+import Header from './Header';
 
 const AppLayout = ({ children }) => {
   return (

--- a/src/components/LectureCardHover.tsx
+++ b/src/components/LectureCardHover.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import AccountTreeOutlinedIcon from '@material-ui/icons/AccountTreeOutlined';
+import AddOutlinedIcon from '@material-ui/icons/AddOutlined';
+import AddShoppingCartOutlinedIcon from '@material-ui/icons/AddShoppingCartOutlined';
+import FavoriteBorderOutlinedIcon from '@material-ui/icons/FavoriteBorderOutlined';
+import LocalOfferOutlinedIcon from '@material-ui/icons/LocalOfferOutlined';
+import SignalCellularAltIcon from '@material-ui/icons/SignalCellularAlt';
+import Link from 'next/link';
+import styled from 'styled-components';
+import { ILecture } from 'src/redux/reducers/types';
+
+const SLectureCardHover = styled.article`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: white;
+  padding: 4px 8px;
+  overflow: auto;
+  font-weight: 550;
+`;
+
+const TagsConatiner = styled.div`
+  color: #c5ebf8;
+`;
+const EachTags = styled.div`
+  display: flex;
+  align-items: center;
+  & > svg {
+    transform: scale(0.7);
+  }
+`;
+
+const IconContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: center;
+  & > svg {
+    transform: scale(0.9);
+    &:hover {
+      cursor: grab;
+    }
+    &:first-child {
+      &:hover {
+        color: #c5ebf8;
+      }
+    }
+    &:nth-child(2) {
+      &:hover {
+        color: #e74c3c;
+      }
+    }
+  }
+`;
+
+type Props = {
+  lecture: ILecture;
+};
+
+const LectureCardHover = ({ lecture }: Props) => {
+  const { title, description, hashTags, categories, level, id } = lecture;
+  console.log('LectureCardHover lecture:', lecture);
+  return (
+    <Link href={`/course/${id}`}>
+      <SLectureCardHover>
+        <h3>{title}</h3>
+        <p>{description}</p>
+        <TagsConatiner>
+          <EachTags>
+            <SignalCellularAltIcon />
+            <span>{level}</span>
+          </EachTags>
+          <EachTags>
+            <AccountTreeOutlinedIcon />
+            {categories?.map((category, index) => {
+              return (
+                <span key={index}>
+                  {category}
+                  {!(index === categories.length - 1) && ', '}
+                </span>
+              );
+            })}
+          </EachTags>
+          <EachTags>
+            <LocalOfferOutlinedIcon />
+            {hashTags?.map((tag, index) => {
+              return (
+                <span key={index}>
+                  {tag}
+                  {!(index === hashTags.length - 1) && ', '}
+                </span>
+              );
+            })}
+          </EachTags>
+        </TagsConatiner>
+        <IconContainer>
+          {/* icons */}
+          <AddShoppingCartOutlinedIcon />
+          <FavoriteBorderOutlinedIcon />
+          <AddOutlinedIcon />
+        </IconContainer>
+      </SLectureCardHover>
+    </Link>
+  );
+};
+
+export default LectureCardHover;

--- a/src/components/LectureCardHover.tsx
+++ b/src/components/LectureCardHover.tsx
@@ -76,23 +76,13 @@ const LectureCardHover = ({ lecture }: Props) => {
           <EachTags>
             <AccountTreeOutlinedIcon />
             {categories?.map((category, index) => {
-              return (
-                <span key={index}>
-                  {category}
-                  {!(index === categories.length - 1) && ', '}
-                </span>
-              );
+              return `${category}${!(index === categories.length - 1) && ', '}`;
             })}
           </EachTags>
           <EachTags>
             <LocalOfferOutlinedIcon />
             {hashTags?.map((tag, index) => {
-              return (
-                <span key={index}>
-                  {tag}
-                  {!(index === hashTags.length - 1) && ', '}
-                </span>
-              );
+              return `${tag}${!(index === hashTags.length - 1) && ', '}`;
             })}
           </EachTags>
         </TagsConatiner>

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Spinner = styled.div`
+  border: 1px solid white;
+  border-top: 1px solid var(--color-light-blue);
+  border-radius: 50%;
+  animation: spin 2s linear infinite;
+  margin: auto;
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+`;
+
+type SpinnerProps = {
+  width?: string;
+  height?: string;
+};
+
+const LoadingSpinner = ({ width = '30px', height = '30px' }: SpinnerProps) => {
+  return <Spinner style={{ width, height }} />;
+};
+
+export default LoadingSpinner;

--- a/src/components/Slider/MainSlider.tsx
+++ b/src/components/Slider/MainSlider.tsx
@@ -36,7 +36,7 @@ const MainSlider = () => {
           autoplaySpeed={5000}
           // dots={true}
         >
-          {console.log(mainSliderList)}
+          {/* {console.log(mainSliderList)} */}
           {mainSliderList.map((item) => (
             <MainSliderItem key={item.id} item={item} />
           ))}

--- a/src/components/lectureCard.tsx
+++ b/src/components/lectureCard.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Link from 'next/link';
 import styled from 'styled-components';
-import RatingStar from 'src/components/ratingStar';
+import RatingStar from '@components/RatingStar';
 import { ILecture } from 'src/redux/reducers/types';
+import LectureCardHover from './LectureCardHover';
 
 const LectureCardStyle = styled.li`
   padding: 12px;
@@ -21,6 +22,7 @@ const LectureCardWrapper = styled.div`
   height: 100%;
   background-color: white;
   cursor: pointer;
+  position: relative;
 `;
 
 const LectureCardImage = styled.div`
@@ -79,11 +81,12 @@ type Props = {
 const LectureCard = ({ lecture }: Props) => {
   const { id, coverImage, title, author, rating, commentCount, price, studentCount } = lecture;
   const studentCountFloor = Math.floor(studentCount / 100) * 100;
+  const [isHover, setIsHover] = useState(false);
 
   return (
     <LectureCardStyle key={id}>
       <Link href={`/course/${id}`}>
-        <LectureCardWrapper>
+        <LectureCardWrapper onMouseEnter={() => setIsHover(true)} onMouseLeave={() => setIsHover(false)}>
           <LectureCardImage style={{ backgroundImage: `url(${coverImage})` }} />
           <div>
             <LectureCardTitle>{title}</LectureCardTitle>
@@ -99,6 +102,8 @@ const LectureCard = ({ lecture }: Props) => {
               <LectureCardTag>{`+${studentCountFloor}명`}</LectureCardTag>
             </div>
           </div>
+          {isHover && <LectureCardHover lecture={lecture} />}
+          {/* <LectureCardHover lecture={lecture} /> */}
         </LectureCardWrapper>
       </Link>
     </LectureCardStyle>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,8 +4,9 @@ import Head from 'next/head';
 import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 import AppLayout from '@components/AppLayout';
+import LectureCard from '@components/LectureCard';
+import LoadingSpinner from '@components/loadingSpinner';
 import { MainSlider } from '@components/Slider';
-import LectureCard from 'src/components/lectureCard';
 import { RootState } from 'src/redux/reducers';
 import { LOAD_ALL_LECTURES_REQUEST } from 'src/redux/reducers/lecture';
 import { ILecture } from 'src/redux/reducers/types';
@@ -88,7 +89,7 @@ const AddLectureBtnWrapper = styled.div`
 `;
 
 const Home = (): ReactNode => {
-  const { mainLectures } = useSelector((state: RootState) => state.lecture);
+  const { mainLectures, loadLectureLoading } = useSelector((state: RootState) => state.lecture);
   const dispatch = useDispatch();
   useEffect(() => {
     dispatch({ type: LOAD_ALL_LECTURES_REQUEST });
@@ -126,11 +127,15 @@ const Home = (): ReactNode => {
         </Search>
         <section className="container">
           <LectureTitle className="title">전체 강의</LectureTitle>
-          <LectureList>
-            {mainLectures?.map((lecture: ILecture) => (
-              <LectureCard key={lecture.id} lecture={lecture} />
-            ))}
-          </LectureList>
+          {loadLectureLoading ? (
+            <LoadingSpinner />
+          ) : (
+            <LectureList>
+              {mainLectures?.map((lecture: ILecture) => (
+                <LectureCard key={lecture.id} lecture={lecture} />
+              ))}
+            </LectureList>
+          )}
         </section>
       </>
     </AppLayout>

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -10,6 +10,7 @@ const Global = createGlobalStyle`
   --color-orange: #feb546;
   --color-yellow: #fdcc11;
   --color-blue: #175cbe;
+  --color-light-blue: #3498db;
   --color-light-pink: hsl(321, 63%, 90%);
 }
 


### PR DESCRIPTION
### 메인페이지 리스트에 로딩 스피너 추가

- 서버사이드 렌더링이기 때문에 필요 없을 것 같기도 함
- 재미로 추가 해봄

### 메인페이지 강의 리스트

- 마우스 호버 시 나오는 description 추가
- [ ] 장바구니, 좋아요 등 아이콘에 설명 라벨 추가 해야 함
- [ ] 카드 전체적으로 크기 키워야 함
- [ ] 해쉬태그 구분 쉼표 다음 띄어쓰기가 적용이 안되는 문제 해결 해야 함