### PR TITLE
fix : 카테고리 버튼 하나만 선택되도록 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,8 +759,48 @@ CourseHeaderContainer height + CourseLayoutGrid padding top(24px) + CourseNav pa
 
 - [ ] 미리 저장했던 데이터 불러와서 데이터 로드해서 넣어야 함
 
+</details>
+
+<details>
+<summary>2021.08.25(Tony)</summary>
+
 ### 카테고리 버튼 중 다른 카테고리 선택하면 현재 선택된 카테고리 색상 원래대로 돌리기
 
-- [ ] 사용하는 곳에서 useState로 변수 하나 만들고 버튼 클릭한 것에 대한 정보(id)를 저장해서 그것과 일치하는지 여부에 따라 true/false를 전달해보자
+- 사용하는 곳에서 useState로 변수 하나 만들고 그것을 prop으로 전달
+
+```typescript
+// course_info.tsx
+const [selectedId, setSelectedId] = useState<string>('');
+
+<CourseCommonButton id="1" text="개발, 프로그래밍" selectedId={selectedId} setSelectedId={setSelectedId} />;
+```
+
+- 버튼 컴포넌트의 onClick에서 버튼 클릭한 것에 대한 정보(id)를 저장
+- 버튼 컴포넌트 안의 useEffect에서 그것과 일치하는지 여부에 따라 true/false를 styled component에 전달
+
+```typescript
+// CourseCommonButton.tsx
+const CourseCommonButton = ({ id, text, selectedId, setSelectedId }: Props) => {
+  const [isSelected, setIsSelected] = useState(false);
+
+  function onClickButton() {
+    setSelectedId(id);
+  }
+
+  useEffect(() => {
+    if (id === selectedId) {
+      setIsSelected(true);
+    } else {
+      setIsSelected(false);
+    }
+  }, [selectedId]);
+
+  return (
+    <CourseCommonButtonStyle onClick={onClickButton} key={id} isSelected={isSelected}>
+      {text}
+    </CourseCommonButtonStyle>
+  );
+};
+```
 
 </details>

--- a/src/components/courseEdit/CourseCommonButton.tsx
+++ b/src/components/courseEdit/CourseCommonButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 type StyleProps = {
@@ -19,19 +19,29 @@ const CourseCommonButtonStyle = styled.button<StyleProps>`
 `;
 
 type Props = {
-  key: string;
+  id: string;
   text: string;
+  selectedId: string;
+  setSelectedId: React.Dispatch<React.SetStateAction<string>>;
 };
 
-const CourseCommonButton = ({ key, text }: Props) => {
+const CourseCommonButton = ({ id, text, selectedId, setSelectedId }: Props) => {
   const [isSelected, setIsSelected] = useState(false);
+
   function onClickButton() {
-    setIsSelected(true);
-    // 리덕스 연결 해서 현재 선택된 key(category id)를 저장
+    setSelectedId(id);
   }
 
+  useEffect(() => {
+    if (id === selectedId) {
+      setIsSelected(true);
+    } else {
+      setIsSelected(false);
+    }
+  }, [selectedId]);
+
   return (
-    <CourseCommonButtonStyle onClick={onClickButton} key={key} isSelected={isSelected}>
+    <CourseCommonButtonStyle onClick={onClickButton} key={id} isSelected={isSelected}>
       {text}
     </CourseCommonButtonStyle>
   );

--- a/src/pages/course/[id]/edit/course_info.tsx
+++ b/src/pages/course/[id]/edit/course_info.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import CourseCommonButton from '@components/courseEdit/CourseCommonButton';
@@ -71,6 +71,7 @@ const CourseInfo = () => {
   const {
     createLectureData: { title },
   } = useSelector((state: RootState) => state.lecture);
+  const [selectedId, setSelectedId] = useState<string>('');
 
   return (
     <CourseLayout>
@@ -102,9 +103,9 @@ const CourseInfo = () => {
       </FieldDiv>
       <FieldDiv>
         <Label>카테고리</Label>
-        <CourseCommonButton key="1" text="개발, 프로그래밍" />
-        <CourseCommonButton key="2" text="보안, 네트워크" />
-        <CourseCommonButton key="3" text="데이터 사이언스" />
+        <CourseCommonButton id="1" text="개발, 프로그래밍" selectedId={selectedId} setSelectedId={setSelectedId} />
+        <CourseCommonButton id="2" text="보안, 네트워크" selectedId={selectedId} setSelectedId={setSelectedId} />
+        <CourseCommonButton id="3" text="데이터 사이언스" selectedId={selectedId} setSelectedId={setSelectedId} />
       </FieldDiv>
     </CourseLayout>
   );


### PR DESCRIPTION
### 카테고리 버튼 중 다른 카테고리 선택하면 현재 선택된 카테고리 색상 원래대로 돌리기

- 사용하는 곳에서 useState로 변수 하나 만들고 그것을 prop으로 전달

```typescript
// course_info.tsx
const [selectedId, setSelectedId] = useState<string>('');

<CourseCommonButton id="1" text="개발, 프로그래밍" selectedId={selectedId} setSelectedId={setSelectedId} />;
```

- 버튼 컴포넌트의 onClick에서 버튼 클릭한 것에 대한 정보(id)를 저장
- 버튼 컴포넌트 안의 useEffect에서 그것과 일치하는지 여부에 따라 true/false를 styled component에 전달

```typescript
// CourseCommonButton.tsx
const CourseCommonButton = ({ id, text, selectedId, setSelectedId }: Props) => {
  const [isSelected, setIsSelected] = useState(false);

  function onClickButton() {
    setSelectedId(id);
  }

  useEffect(() => {
    if (id === selectedId) {
      setIsSelected(true);
    } else {
      setIsSelected(false);
    }
  }, [selectedId]);

  return (
    <CourseCommonButtonStyle onClick={onClickButton} key={id} isSelected={isSelected}>
      {text}
    </CourseCommonButtonStyle>
  );
};
```