### PR TITLE
fix : redirect with redux(issue#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 인프런 웹앱을 만들어보는 팀프로젝트
 
-[Inflearn-clone-back repository](https://github.com/TaehwanGo/inflearn-clone-back)
+[Inflearn-clone-back repository](https://github.com/Ark-inflearn/inflearn-clone-back)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -837,6 +837,7 @@ data : {
 - [dynamically-add-child-components-in-react](https://stackoverflow.com/questions/36651583/dynamically-add-child-components-in-react)
 
 </details>
+
 <details>
 <summary>2021.08.27(NOAH)</summary>
 
@@ -875,5 +876,22 @@ const throttledScroll = useMemo(
 ### 추 후 확인
 
 - 일단 레이아웃이 되도록 CSS를 덕지덕지 붙여놨는데 효율적으로 할 수 있도록 검토해야 함
+
+</details>
+
+<details>
+<summary>2021.08.27(Tony)</summary>
+
+### 강의생성 후 window api로 페이지 이동시 데이터 날라가는 문제
+
+- window.location.href 를 사용하면 페이지가 새로고침되면서 자바스크립트(리덕스 스토어)에 있는 모든 데이터가 날라감
+
+- react나 next에서 제공하는 router를 saga에서 사용해야 되는데
+  useRouter나 useHistory는 hook이기 때문에 component가 아닌 saga에선 사용이 불가능 함(hooks rule)
+
+- 문제 해결
+  - saga에서 페이지 이동을 시키려 했으나 위와 같은 문제로 잘 되지 않음
+  - 'history', 'react-router-redux' 라이브러리 둘다 써봤는데 typescript문제인지 next문제인지 뭔지 잘 되지 않음
+  - 기존 방식 대로 컴포넌트에서 페이지를 이동 시키는 대신 flag로 사용중인 done변수를 false로 만드는 dispatch를 실행문 마지막에 추가해서 성공
 
 </details>

--- a/src/pages/create_course.tsx
+++ b/src/pages/create_course.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 import AppLayout from 'src/layouts/AppLayout';
 import { RootState } from 'src/redux/reducers';
-import { CREATE_LECTURE_REQUEST, LOAD_CREATE_LECTURE } from 'src/redux/reducers/lecture';
+import { CREATE_LECTURE_REQUEST, DONE_CREATE_LECTURE } from 'src/redux/reducers/lecture';
 
 const InputTitle = styled.input`
   padding: 0 10px;
@@ -78,20 +78,16 @@ const CreateCourse = () => {
     (state: RootState) => state.lecture
   );
 
-  // useEffect(() => { // 이렇게 해도 아래 useEffect가 실행이 돼서 뒤로가기를 두번 눌러야 만들기 페이지로 이동됨
-  //   dispatch({
-  //     type: LOAD_CREATE_LECTURE,
-  //   });
-  // }, []);
+  useEffect(() => {
+    if (createLectureDone) {
+      const { id } = createLectureData;
+      dispatch({
+        type: DONE_CREATE_LECTURE,
+      });
+      router.push(`/course/${id}/edit/course_info`);
+    }
+  }, [createLectureDone]);
 
-  // useEffect(() => {
-  //   console.log('create_course useEffect');
-  //   if (createLectureDone) {
-  //     console.log('create_course useEffect createLectureDone');
-  //     const { id } = createLectureData;
-  //     router.push(`/course/${id}/edit/course_info`);
-  //   }
-  // }, [createLectureDone]);
   const handleSubmit = async () => {
     const title = inputTitle?.current?.value;
     console.log('title', title);

--- a/src/redux/reducers/lecture.ts
+++ b/src/redux/reducers/lecture.ts
@@ -43,7 +43,7 @@ export const CREATE_LECTURE_REQUEST = 'CREATE_LECTURE_REQUEST';
 export const CREATE_LECTURE_SUCCESS = 'CREATE_LECTURE_SUCCESS';
 export const CREATE_LECTURE_FAILURE = 'CREATE_LECTURE_FAILURE';
 
-export const LOAD_CREATE_LECTURE = 'LOAD_CREATE_LECTURE';
+export const DONE_CREATE_LECTURE = 'DONE_CREATE_LECTURE';
 
 // reducer
 const reducer = (state = initialState, action: IAction) => {
@@ -89,9 +89,9 @@ const reducer = (state = initialState, action: IAction) => {
         draft.createLectureDone = true;
         draft.createLectureError = action.error;
         break;
-      // case LOAD_CREATE_LECTURE:
-      //   draft.createLectureDone = false;
-      //   break;
+      case DONE_CREATE_LECTURE:
+        draft.createLectureDone = false;
+        break;
 
       // 나머지 추후 추가 예정
       default:

--- a/src/redux/sagas/lecture.ts
+++ b/src/redux/sagas/lecture.ts
@@ -1,6 +1,5 @@
 import { all, call, delay, fork, put, takeLatest, throttle } from '@redux-saga/core/effects';
 import axios from 'axios';
-import { useRouter } from 'next/dist/client/router';
 import { generateDummyLectureList, mainSliderData } from 'src/api/dummyData';
 import {
   CREATE_LECTURE_FAILURE,
@@ -73,7 +72,6 @@ function* createLecture(action: IAction): any {
       // data: result?.data?.lectureId,
       data: 1,
     });
-    yield (window.location.href = `/course/${1}/edit/course_info`);
   } catch (err) {
     yield put({
       type: CREATE_LECTURE_FAILURE,


### PR DESCRIPTION
### 강의생성 후 window api로 페이지 이동시 데이터 날라가는 문제
- 문제 해결
  - saga에서 페이지 이동을 시키려 했으나 #47 같은 문제로 잘 되지 않음
  - 'history', 'react-router-redux' 라이브러리 둘다 써봤는데 typescript문제인지 next문제인지 뭔지 잘 되지 않음
  - 기존 방식 대로 컴포넌트에서 페이지를 이동 시키는 대신 flag로 사용중인 done변수를 false로 만드는 dispatch를 실행문 마지막에 추가해서 성공