### PR TITLE
Course layout redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,6 +905,20 @@ const throttledScroll = useMemo(
 
 ### children component에 props 전달하기
 
+```typescript
+<CourseMain>
+  {console.log('React.isValidElement(children)', React.isValidElement(children))}
+  {React.isValidElement(children) && React.cloneElement(children, { lectureData })}
+  {/* {React.Children.map<React.ReactNode, React.ReactNode>(children, (child) => {
+            if (React.isValidElement(child)) {
+              return React.cloneElement(child, { lectureData });
+            }
+          })} */}
+  {/* {children} */}
+</CourseMain>
+// 결론 안됨 => each child에서 store에서 데이터 가져오기
+```
+
 - each child에서 store에서 데이터 가져오기
 
 ### typescript에서 initial data 를 하나하나 다 넣어줘야되는건지 알아보기

--- a/README.md
+++ b/README.md
@@ -915,6 +915,12 @@ const throttledScroll = useMemo(
 
 - [children component에 props 전달하기](https://eomtttttt-develop.tistory.com/203)
   - `This JSX tag's 'children' prop expects a single child of type 'ReactElement<any, string | JSXElementConstructor<any>>', but multiple children were provided.` => 안됨
+  - https://stackoverflow.com/questions/42261783/how-to-assign-the-correct-typing-to-react-cloneelement-when-giving-properties-to
+    - 안됨 : React.isValidElement(children) 통과가 안됨
+  - https://www.geeksforgeeks.org/how-to-use-react-cloneelement-function/
+  - [리액트 요소 검증하기](https://webisfree.com/2020-08-26/[react]-%EB%A6%AC%EC%95%A1%ED%8A%B8-%EC%9A%94%EC%86%8C-%EA%B2%80%EC%A6%9D%ED%95%98%EA%B8%B0-isvalidelement)
+    - 하나 짜리만 됨(`<div>하나<div>` 같은)
+      - 하나 짜리도 props 전달이 잘 안됨
 - [react-children with typescript](https://www.carlrippon.com/react-children-with-typescript/)
 
 </details>

--- a/README.md
+++ b/README.md
@@ -895,3 +895,26 @@ const throttledScroll = useMemo(
   - 기존 방식 대로 컴포넌트에서 페이지를 이동 시키는 대신 flag로 사용중인 done변수를 false로 만드는 dispatch를 실행문 마지막에 추가해서 성공
 
 </details>
+
+<details>
+<summary>2021.08.28(Tony)</summary>
+
+### 강의 수정 페이지 로드 시 데이터 받아오기(redux saga)
+
+- 확인
+
+### children component에 props 전달하기
+
+- each child에서 store에서 데이터 가져오기
+
+### typescript에서 initial data 를 하나하나 다 넣어줘야되는건지 알아보기
+
+- 초기값을 다 넣어줘야 될 것 같음
+
+### 참고문헌
+
+- [children component에 props 전달하기](https://eomtttttt-develop.tistory.com/203)
+  - `This JSX tag's 'children' prop expects a single child of type 'ReactElement<any, string | JSXElementConstructor<any>>', but multiple children were provided.` => 안됨
+- [react-children with typescript](https://www.carlrippon.com/react-children-with-typescript/)
+
+</details>

--- a/src/api/dummyData.ts
+++ b/src/api/dummyData.ts
@@ -1,6 +1,6 @@
 import faker from 'faker';
 import shortId from 'shortid';
-import { ILecture, IMainSliderData, IUser } from 'src/redux/reducers/types';
+import { ILecture, IMainSliderData, IUser, LectureData } from 'src/redux/reducers/types';
 
 export const dummyUser: IUser = {
   id: 1,
@@ -135,3 +135,24 @@ export const mainSliderData: IMainSliderData[] = [
     btnTitle: '인프런은 🌱',
   },
 ];
+
+export const dummyLectureEditData: LectureData = {
+  courseInfo: {
+    id: 1,
+    title: 'title from server',
+    whatYouCanLearn: ['당신은', '이것을', '배울 수 있습니다.'],
+    expectedStudents: ['예상', '되는', '수강생들'],
+    requiredKnowledge: ['자신만의', '철학', '열정'],
+    category: [
+      {
+        id: '1',
+        name: 'category1',
+      },
+      {
+        id: '2',
+        name: 'category2',
+      },
+    ],
+    level: 'basic',
+  },
+};

--- a/src/layouts/CourseLayout.tsx
+++ b/src/layouts/CourseLayout.tsx
@@ -7,7 +7,6 @@ import styled from 'styled-components';
 import Header from '@components/HeaderLayout';
 import { RootState } from 'src/redux/reducers';
 import { LOAD_EDIT_LECTURE_REQUEST } from 'src/redux/reducers/lecture';
-import { IAction } from 'src/redux/reducers/types';
 
 const CourseLayoutContainer = styled.section`
   background-color: #f5f5f5;
@@ -208,16 +207,7 @@ const CourseLayout = ({ children }: IProps) => {
             </StepItem>
           </StepContainer>
         </CourseNav>
-        <CourseMain>
-          {console.log('React.isValidElement(children)', React.isValidElement(children))}
-          {React.isValidElement(children) && React.cloneElement(children, { lectureData })}
-          {/* {React.Children.map<React.ReactNode, React.ReactNode>(children, (child) => {
-            if (React.isValidElement(child)) {
-              return React.cloneElement(child, { lectureData });
-            }
-          })} */}
-          {/* {children} */}
-        </CourseMain>
+        <CourseMain>{children}</CourseMain>
         <CourseAside>
           <StepContainer headerHeight={headerHeight}>눈길을 끄는 제목 작성 꿀팁!</StepContainer>
         </CourseAside>

--- a/src/layouts/CourseLayout.tsx
+++ b/src/layouts/CourseLayout.tsx
@@ -208,7 +208,16 @@ const CourseLayout = ({ children }: IProps) => {
             </StepItem>
           </StepContainer>
         </CourseNav>
-        <CourseMain>{children}</CourseMain>
+        <CourseMain>
+          {console.log('React.isValidElement(children)', React.isValidElement(children))}
+          {React.isValidElement(children) && React.cloneElement(children, { lectureData })}
+          {/* {React.Children.map<React.ReactNode, React.ReactNode>(children, (child) => {
+            if (React.isValidElement(child)) {
+              return React.cloneElement(child, { lectureData });
+            }
+          })} */}
+          {/* {children} */}
+        </CourseMain>
         <CourseAside>
           <StepContainer headerHeight={headerHeight}>눈길을 끄는 제목 작성 꿀팁!</StepContainer>
         </CourseAside>

--- a/src/layouts/CourseLayout.tsx
+++ b/src/layouts/CourseLayout.tsx
@@ -2,8 +2,12 @@ import React, { useRef, useEffect, useState } from 'react';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import { useRouter } from 'next/dist/client/router';
 import Link from 'next/link';
+import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 import Header from '@components/HeaderLayout';
+import { RootState } from 'src/redux/reducers';
+import { LOAD_EDIT_LECTURE_REQUEST } from 'src/redux/reducers/lecture';
+import { IAction } from 'src/redux/reducers/types';
 
 const CourseLayoutContainer = styled.section`
   background-color: #f5f5f5;
@@ -128,12 +132,24 @@ const CourseLayout = ({ children }: IProps) => {
   const { id } = router.query;
   const refCourseHeader = useRef<HTMLDivElement>(null);
   const [headerHeight, setHeaderHeight] = useState<number>(64);
+  const dispatch = useDispatch();
+  const { lectureData } = useSelector((state: RootState) => state.lecture);
 
   function getCurrentPath() {
     const currentUrl = router.pathname.split('edit')[1];
     // console.log(currentUrl);
     return currentUrl;
   }
+
+  useEffect(() => {
+    dispatch({
+      type: LOAD_EDIT_LECTURE_REQUEST,
+    });
+  }, []);
+
+  useEffect(() => {
+    console.log('lectureData', lectureData);
+  }, [lectureData]);
 
   useEffect(() => {
     getCurrentPath();

--- a/src/layouts/CourseLayout.tsx
+++ b/src/layouts/CourseLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useState } from 'react';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
-import { NextRouter, useRouter } from 'next/dist/client/router';
+import { useRouter } from 'next/dist/client/router';
 import Link from 'next/link';
 import styled from 'styled-components';
 import Header from '@components/HeaderLayout';
@@ -127,7 +127,7 @@ const CourseLayout = ({ children }: IProps) => {
   const router = useRouter();
   const { id } = router.query;
   const refCourseHeader = useRef<HTMLDivElement>(null);
-  const [headerHeight, setHeaderHeight] = useState<number>();
+  const [headerHeight, setHeaderHeight] = useState<number>(64);
 
   function getCurrentPath() {
     const currentUrl = router.pathname.split('edit')[1];
@@ -137,7 +137,9 @@ const CourseLayout = ({ children }: IProps) => {
 
   useEffect(() => {
     getCurrentPath();
-    setHeaderHeight(refCourseHeader.current?.clientHeight);
+    if (refCourseHeader.current) {
+      setHeaderHeight(refCourseHeader.current.clientHeight);
+    }
   }, [headerHeight]);
   return (
     <CourseLayoutContainer>

--- a/src/pages/course/[id]/edit/course_info.tsx
+++ b/src/pages/course/[id]/edit/course_info.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import CourseCommonButton from '@components/courseEdit/CourseCommonButton';
@@ -6,6 +6,7 @@ import CourseTitle from '@components/courseEdit/CourseTitle';
 import CourseTitleLabel from '@components/courseEdit/CourseTitleLabel';
 import CourseLayout from 'src/layouts/CourseLayout';
 import { RootState } from 'src/redux/reducers';
+import { ILectureInfo } from 'src/redux/reducers/types';
 
 const BoxInput = styled.input`
   border: 0;
@@ -67,11 +68,17 @@ const OptionalText = styled.span`
   font-weight: 400;
 `;
 
-const CourseInfo = () => {
-  const {
-    createLectureData: { title },
-  } = useSelector((state: RootState) => state.lecture);
+type Props = {
+  courseInfo: ILectureInfo;
+};
+
+const CourseInfo = ({ courseInfo }: Props) => {
+  const { createLectureData } = useSelector((state: RootState) => state.lecture);
+  const title = createLectureData?.title;
   const [selectedId, setSelectedId] = useState<string>('');
+  useEffect(() => {
+    console.log('courseInfo', courseInfo);
+  }, []);
 
   return (
     <CourseLayout>

--- a/src/pages/course/[id]/edit/course_info.tsx
+++ b/src/pages/course/[id]/edit/course_info.tsx
@@ -68,17 +68,13 @@ const OptionalText = styled.span`
   font-weight: 400;
 `;
 
-type Props = {
-  lectureData: LectureData;
-};
-
-function CourseInfo({ lectureData }: Props) {
-  const { createLectureData } = useSelector((state: RootState) => state.lecture);
+function CourseInfo() {
+  const { createLectureData, lectureData } = useSelector((state: RootState) => state.lecture);
   const title = createLectureData?.title;
   const [selectedId, setSelectedId] = useState<string>('');
   useEffect(() => {
     console.log('CourseInfo lectureData', lectureData);
-  }, []);
+  }, [lectureData]);
 
   return (
     <CourseLayout>

--- a/src/pages/course/[id]/edit/course_info.tsx
+++ b/src/pages/course/[id]/edit/course_info.tsx
@@ -6,7 +6,7 @@ import CourseTitle from '@components/courseEdit/CourseTitle';
 import CourseTitleLabel from '@components/courseEdit/CourseTitleLabel';
 import CourseLayout from 'src/layouts/CourseLayout';
 import { RootState } from 'src/redux/reducers';
-import { ILectureInfo } from 'src/redux/reducers/types';
+import { ILectureInfo, LectureData } from 'src/redux/reducers/types';
 
 const BoxInput = styled.input`
   border: 0;
@@ -69,15 +69,15 @@ const OptionalText = styled.span`
 `;
 
 type Props = {
-  courseInfo: ILectureInfo;
+  lectureData: LectureData;
 };
 
-const CourseInfo = ({ courseInfo }: Props) => {
+function CourseInfo({ lectureData }: Props) {
   const { createLectureData } = useSelector((state: RootState) => state.lecture);
   const title = createLectureData?.title;
   const [selectedId, setSelectedId] = useState<string>('');
   useEffect(() => {
-    console.log('courseInfo', courseInfo);
+    console.log('CourseInfo lectureData', lectureData);
   }, []);
 
   return (
@@ -116,6 +116,6 @@ const CourseInfo = ({ courseInfo }: Props) => {
       </FieldDiv>
     </CourseLayout>
   );
-};
+}
 
 export default CourseInfo;

--- a/src/pages/course/[id]/edit/cover_image.tsx
+++ b/src/pages/course/[id]/edit/cover_image.tsx
@@ -1,7 +1,15 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import CourseLayout from '@layouts/CourseLayout';
+import { LectureData } from 'src/redux/reducers/types';
 
-const CoverImage = () => {
+type Props = {
+  lectureData: LectureData;
+};
+
+const CoverImage = ({ lectureData }: Props) => {
+  useEffect(() => {
+    console.log('CoverImage', lectureData);
+  }, [lectureData]);
   return (
     <CourseLayout>
       <div>커버 이미지</div>

--- a/src/pages/course/[id]/edit/cover_image.tsx
+++ b/src/pages/course/[id]/edit/cover_image.tsx
@@ -1,15 +1,7 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import CourseLayout from '@layouts/CourseLayout';
-import { LectureData } from 'src/redux/reducers/types';
 
-type Props = {
-  lectureData: LectureData;
-};
-
-const CoverImage = ({ lectureData }: Props) => {
-  useEffect(() => {
-    console.log('CoverImage', lectureData);
-  }, [lectureData]);
+const CoverImage = () => {
   return (
     <CourseLayout>
       <div>커버 이미지</div>

--- a/src/redux/reducers/lecture.ts
+++ b/src/redux/reducers/lecture.ts
@@ -1,5 +1,5 @@
 import produce from 'immer';
-import { IAction, ICreateLectureData, ILecture, IMainSliderData } from './types';
+import { IAction, ILectureInfo, ILecture, IMainSliderData, LectureData } from './types';
 
 // redux lecture state
 export interface ILectureState {
@@ -13,7 +13,10 @@ export interface ILectureState {
   createLectureLoading: boolean;
   createLectureDone: boolean;
   createLectureError?: string;
-  createLectureData: ICreateLectureData;
+  createLectureData: ILectureInfo;
+  editLectureLoading: boolean;
+  editLectureError?: string;
+  lectureData?: LectureData; // edit page layout에서 불러오는 data
 }
 
 export const initialState: ILectureState = {
@@ -25,9 +28,18 @@ export const initialState: ILectureState = {
   loadSliderLoading: true,
   loadSliderError: '',
   createLectureLoading: false,
-  createLectureData: { id: undefined, title: undefined },
+  createLectureData: {
+    id: undefined,
+    title: undefined,
+    whatYouCanLearn: [],
+    expectedStudents: [],
+    requiredKnowledge: [],
+    category: [],
+    level: '',
+  },
   createLectureError: undefined,
   createLectureDone: false,
+  editLectureLoading: false,
 };
 
 // action types
@@ -44,6 +56,11 @@ export const CREATE_LECTURE_SUCCESS = 'CREATE_LECTURE_SUCCESS';
 export const CREATE_LECTURE_FAILURE = 'CREATE_LECTURE_FAILURE';
 
 export const DONE_CREATE_LECTURE = 'DONE_CREATE_LECTURE';
+
+// edit course page action
+export const LOAD_EDIT_LECTURE_REQUEST = 'LOAD_EDIT_LECTURE_REQUEST';
+export const LOAD_EDIT_LECTURE_SUCCESS = 'LOAD_EDIT_LECTURE_SUCCESS';
+export const LOAD_EDIT_LECTURE_FAILURE = 'LOAD_EDIT_LECTURE_FAILURE';
 
 // reducer
 const reducer = (state = initialState, action: IAction) => {
@@ -91,6 +108,18 @@ const reducer = (state = initialState, action: IAction) => {
         break;
       case DONE_CREATE_LECTURE:
         draft.createLectureDone = false;
+        break;
+
+      case LOAD_EDIT_LECTURE_REQUEST:
+        draft.editLectureLoading = true;
+        break;
+      case LOAD_EDIT_LECTURE_SUCCESS:
+        draft.editLectureLoading = false;
+        draft.lectureData = action.data;
+        break;
+      case LOAD_EDIT_LECTURE_FAILURE:
+        draft.editLectureLoading = false;
+        draft.editLectureError = action.error;
         break;
 
       // 나머지 추후 추가 예정

--- a/src/redux/reducers/types.ts
+++ b/src/redux/reducers/types.ts
@@ -53,7 +53,20 @@ export interface IAction {
 }
 
 // CreateLectureData
-export interface ICreateLectureData {
+export interface ILectureInfo {
   id?: number;
   title?: string;
+  whatYouCanLearn: string[];
+  expectedStudents: string[];
+  requiredKnowledge: string[];
+  category: {
+    id: string;
+    name: string;
+  }[];
+  level: string;
 }
+
+// Lecture data on load edit page
+export type LectureData = {
+  courseInfo: ILectureInfo;
+};

--- a/src/redux/sagas/lecture.ts
+++ b/src/redux/sagas/lecture.ts
@@ -1,6 +1,6 @@
 import { all, call, delay, fork, put, takeLatest, throttle } from '@redux-saga/core/effects';
 import axios from 'axios';
-import { generateDummyLectureList, mainSliderData } from 'src/api/dummyData';
+import { dummyLectureEditData, generateDummyLectureList, mainSliderData } from 'src/api/dummyData';
 import {
   CREATE_LECTURE_FAILURE,
   CREATE_LECTURE_REQUEST,
@@ -11,6 +11,9 @@ import {
   LOAD_SLIDER_FAILURE,
   LOAD_SLIDER_REQUEST,
   LOAD_SLIDER_SUCCESS,
+  LOAD_EDIT_LECTURE_REQUEST,
+  LOAD_EDIT_LECTURE_SUCCESS,
+  LOAD_EDIT_LECTURE_FAILURE,
 } from '../reducers/lecture';
 import { IAction } from '../reducers/types';
 
@@ -80,6 +83,23 @@ function* createLecture(action: IAction): any {
   }
 }
 
+function* loadEditPage() {
+  try {
+    yield delay(1000);
+    yield put({
+      type: LOAD_EDIT_LECTURE_SUCCESS,
+      data: dummyLectureEditData,
+    });
+  } catch (err) {
+    yield put({
+      type: LOAD_EDIT_LECTURE_FAILURE,
+      error: err,
+    });
+  }
+}
+
+// watch function*
+
 function* watchLoadMainPage() {
   yield throttle(3000, LOAD_ALL_LECTURES_REQUEST, loadMainPage);
 }
@@ -92,6 +112,10 @@ function* watchCreateLecture() {
   yield throttle(1000, CREATE_LECTURE_REQUEST, createLecture);
 }
 
+function* watchLoadEditPage() {
+  yield takeLatest(LOAD_EDIT_LECTURE_REQUEST, loadEditPage);
+}
+
 export default function* lectureSaga() {
-  yield all([fork(watchLoadMainPage), fork(watchLoadSlider), fork(watchCreateLecture)]);
+  yield all([fork(watchLoadMainPage), fork(watchLoadSlider), fork(watchCreateLecture), fork(watchLoadEditPage)]);
 }


### PR DESCRIPTION
강의 수정 페이지 로드 시 리덕스 데이터 가져오도록 했습니다.

수정 페이지 공통으로 사용하는 레이아웃에서 데이터를 가져오기 때문에 
각 children compoenet에 prop으로 넘겨주려 했지만 현재로선 방법을 찾지 못 했습니다.
그래서 각 child component에서 다시 한번 리덕스 store에서 데이터를 가져오는 방식으로 사용하려하고 있고
console.log로 데이터 가져오는 것 까지 확인한 상태입니다.