### PR TITLE
강의 페이지 레이아웃 대략적으로 구현 및 강의 검색하기 부분 디자인 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1128,6 +1128,7 @@ export default useInput;
 - 간편 로그인
 
 </details>
+<details>
 <summary>2021.09.14(NOAH)</summary>
 
 ## 비밀번호 찾기 Modal 구현 (Portal 사용)

--- a/README.md
+++ b/README.md
@@ -1182,3 +1182,19 @@ export default function Portal({ children, selector }: IProps) {
 - 백엔드쪽에 Router가 구현된 후 API 연결 테스트를 해야 함
 
 </details>
+<details>
+<summary>2021.09.19(나현)</summary>
+
+## 구현한 것
+
+- 강의 페이지 레이아웃을 대략적으로 구현 
+- 강의 카테고리와 필터(난이도, 유·무료 선택, 온라인/오프라인)를 각각 CategoryMenu 컴포넌트와 LectureFilter 컴포넌트로 분리 
+- 강의 검색하기 부분 디자인 구현
+  - 인프런 CSS 참고함.
+
+## 앞으로 진행할 작업
+
+- 더미데이터로 강의 리스트 나타내기
+- 카드 정렬 스타일을 선택하는 Grid와 List 버튼 구현하기
+
+</details>

--- a/src/components/CategoryMenu.tsx
+++ b/src/components/CategoryMenu.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const CategoryMenu = () => {
+  return (
+    <>
+      <div>카테고리 메뉴</div>
+    </>
+  );
+};
+
+export default CategoryMenu;

--- a/src/components/CategoryMenu.tsx
+++ b/src/components/CategoryMenu.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 const CategoryMenu = () => {
   return (
     <>
-      <div>카테고리 메뉴</div>
+      <nav>카테고리 메뉴</nav>
     </>
   );
 };

--- a/src/components/LectureFilter.tsx
+++ b/src/components/LectureFilter.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const LectureFilter = () => {
+  return (
+    <>
+      <div>강의 필터</div>
+    </>
+  );
+};
+
+export default LectureFilter;

--- a/src/pages/courses/index.tsx
+++ b/src/pages/courses/index.tsx
@@ -23,7 +23,51 @@ const CoursesWrapper = styled.div`
   }
 `;
 
+const CoursesHeader = styled.header`
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid #dedede;
+`;
+
+const LectureSearchForm = styled.form`
+  display: flex;
+  justify-content: flex-end;
+
+  @media screen and (max-width: 768px) {
+    justify-content: center;
+  }
+`;
+
+const LectureSearchInput = styled.input`
+  flex: 1 1 300px;
+  max-width: 300px;
+  height: 36px;
+  padding: 5px 9px;
+  border: 1px solid #dedede;
+
+  &:focus {
+    outline: 0.05cm auto #1dc078;
+  }
+
+  &&::placeholder {
+    color: #b8b8b8db;
+  }
+`;
+
+const LectrueSearchBtn = styled.button`
+  width: 53px;
+  height: 36px;
+  background: #1dc078;
+  color: white;
+  font-size: 1rem;
+  font-weight: 800;
+  margin-left: -1rem;
+`;
+
 const Courses = () => {
+  const handleSubmit = () => {
+    console.log('success!');
+  };
+
   return (
     <AppLayout>
       <CoursesSection>
@@ -34,7 +78,12 @@ const Courses = () => {
               <LectureFilter />
             </Grid>
             <Grid item xs={10} style={{ padding: '0 0.75rem' }}>
-              <div>검색하기</div>
+              <CoursesHeader>
+                <LectureSearchForm name="lectureSearch" onSubmit={handleSubmit}>
+                  <LectureSearchInput type="text" placeholder="강의 검색하기" />
+                  <LectrueSearchBtn type="submit">검색</LectrueSearchBtn>
+                </LectureSearchForm>
+              </CoursesHeader>
               <nav>카테고리 경로</nav>
               <span>Grid와 list 선택</span>
               <span>카드 정렬 선택</span>

--- a/src/pages/courses/index.tsx
+++ b/src/pages/courses/index.tsx
@@ -53,7 +53,7 @@ const LectureSearchInput = styled.input`
   }
 `;
 
-const LectrueSearchBtn = styled.button`
+const LectureSearchBtn = styled.button`
   width: 53px;
   height: 36px;
   background: #1dc078;
@@ -81,7 +81,7 @@ const Courses = () => {
               <CoursesHeader>
                 <LectureSearchForm name="lectureSearch" onSubmit={handleSubmit}>
                   <LectureSearchInput type="text" placeholder="강의 검색하기" />
-                  <LectrueSearchBtn type="submit">검색</LectrueSearchBtn>
+                  <LectureSearchBtn type="submit">검색</LectureSearchBtn>
                 </LectureSearchForm>
               </CoursesHeader>
               <nav>카테고리 경로</nav>

--- a/src/pages/courses/index.tsx
+++ b/src/pages/courses/index.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import Grid from '@material-ui/core/Grid';
+import styled from 'styled-components';
+import CategoryMenu from '@components/CategoryMenu';
+import LectureFilter from '@components/LectureFilter';
+import AppLayout from 'src/layouts/AppLayout';
+
+const CoursesSection = styled.section`
+  background: white;
+`;
+
+const CoursesWrapper = styled.div`
+  padding: 2rem 0;
+  margin: 0 auto;
+  background: white;
+
+  @media screen and (min-width: 1200px) {
+    max-width: 1180px;
+  }
+
+  @media screen and (min-width: 1473px) {
+    max-width: 1440px;
+  }
+`;
+
+const Courses = () => {
+  return (
+    <AppLayout>
+      <CoursesSection>
+        <CoursesWrapper>
+          <Grid container>
+            <Grid item xs={2}>
+              <CategoryMenu />
+              <LectureFilter />
+            </Grid>
+            <Grid item xs={10} style={{ padding: '0 0.75rem' }}>
+              <div>검색하기</div>
+              <nav>카테고리 경로</nav>
+              <span>Grid와 list 선택</span>
+              <span>카드 정렬 선택</span>
+              <div>기술검색</div>
+              <div>강의 카드</div>
+              <div>페이지네이션</div>
+            </Grid>
+          </Grid>
+        </CoursesWrapper>
+      </CoursesSection>
+      <section>지식공유참여 및 인프런 비즈니스</section>
+    </AppLayout>
+  );
+};
+
+export default Courses;


### PR DESCRIPTION
## 구현한 것

- 강의 페이지 레이아웃을 대략적으로 구현 
- 강의 카테고리와 필터(난이도, 유·무료, 온라인/오프라인 등의 선택)를 각각 CategoryMenu 컴포넌트와 LectureFilter 컴포넌트로 분리 
- 강의 검색하기 부분 디자인 구현
  - 인프런 CSS 참고함.

## 앞으로 진행할 작업

- 더미 데이터로 강의 리스트 나타내기
- 카드 정렬 스타일을 선택하는 Grid와 List 버튼 구현하기